### PR TITLE
Add corrected track momentum variables to an HpsParticle and change name of method used to get the invariant mass.

### DIFF
--- a/include/hps_event/HpsParticle.h
+++ b/include/hps_event/HpsParticle.h
@@ -216,7 +216,7 @@ class HpsParticle : public TObject {
          *
          * @return The invariant mass of the particle in GeV
          */
-        double Mass() const { return mass; }; 
+        double getMass() const { return mass; }; 
         
         /**
          * Get the momentum of the particle in GeV.

--- a/include/hps_event/HpsParticle.h
+++ b/include/hps_event/HpsParticle.h
@@ -29,15 +29,15 @@ class HpsParticle : public TObject {
     public:
 
         /** Enum constants used to denote the different particle types */
-		enum ParticleType { 
-			FINAL_STATE_PARTICLE = 0,
-			UC_V0_CANDIDATE	     = 1, 
-			BSC_V0_CANDIDATE	 = 2, 
-			TC_V0_CANDIDATE	     = 3,
-			UC_MOLLER_CANDIDATE	 = 4, 
-			BSC_MOLLER_CANDIDATE = 5, 
-			TC_MOLLER_CANDIDATE	 = 6,
-		};
+        enum ParticleType { 
+            FINAL_STATE_PARTICLE = 0,
+            UC_V0_CANDIDATE      = 1, 
+            BSC_V0_CANDIDATE     = 2, 
+            TC_V0_CANDIDATE      = 3,
+            UC_MOLLER_CANDIDATE  = 4, 
+            BSC_MOLLER_CANDIDATE = 5, 
+            TC_MOLLER_CANDIDATE  = 6,
+        };
 
         /** Default Constructor. */
         HpsParticle(); 
@@ -133,9 +133,17 @@ class HpsParticle : public TObject {
          * Set the momentum of the particle in GeV.
          *
          * @param momentum An array containing the three momentum components 
-         *                 of the particle
+         *                 of the particle.
          */
-        void setMomentum(const double* momentum); 
+        void setMomentum(const double* momentum);
+
+        /**
+         * Set the corrected momentum of the paritcle in GeV.
+         *
+         * @param momentum An array containing the three momentum components
+         *                 of the particle.
+         */
+        void setCorrMomentum(const double* momentum);  
 
         /**
          * Set the vertex position of the particle.
@@ -224,7 +232,15 @@ class HpsParticle : public TObject {
          * @return The momentum of the particle
          */
         std::vector<double> getMomentum() const;  
-        
+       
+        /**
+         * Get the corrected momentum of the paritcle in GeV.
+         *
+         * @param momentum An array containing the three corrected momentum
+         *                 components of the particle.
+         */
+        std::vector<double> getCorrMomentum() const;  
+
         /**
          * Get the vertex position of the particle.
          *
@@ -276,11 +292,20 @@ class HpsParticle : public TObject {
         /** The x component of the momentum of this particle in GeV */
         double px; 
 
+        /** The x component of the corrected momentum of this particle in GeV */
+        double px_corr; 
+
         /** The y component of the momentum of this particle in GeV */
         double py; 
 
+        /** The y component of the corrected momentum of this particle in GeV */
+        double py_corr; 
+        
         /** The z component of the momentum of this particle in GeV */
         double pz;
+        
+        /** The z component of the corrected momentum of this particle in GeV */
+        double pz_corr;
 
         /** The x component of the vertex of this particle in mm*/
         double vtx_x;

--- a/src/hps_event/HpsParticle.cxx
+++ b/src/hps_event/HpsParticle.cxx
@@ -24,8 +24,11 @@ HpsParticle::HpsParticle()
       pdg(0), 
       goodness_pid(-9999),   
       px(0),
+      px_corr(0), 
       py(0),
+      py_corr(0),
       pz(0),
+      pz_corr(0),
       vtx_x(0),
       vtx_y(0),
       vtx_z(0),
@@ -45,8 +48,11 @@ HpsParticle::HpsParticle(const HpsParticle &particle_obj)
       pdg(particle_obj.pdg), 
       goodness_pid(particle_obj.goodness_pid), 
       px(particle_obj.px),
+      px_corr(particle_obj.px_corr),
       py(particle_obj.py),
+      py_corr(particle_obj.py_corr),
       pz(particle_obj.pz), 
+      pz_corr(particle_obj.pz_corr),
       vtx_x(particle_obj.vtx_x),
       vtx_y(particle_obj.vtx_y),
       vtx_z(particle_obj.vtx_z),
@@ -80,8 +86,11 @@ HpsParticle &HpsParticle::operator=(const HpsParticle &particle_obj) {
     this->goodness_pid = particle_obj.goodness_pid; 
 
     this->px = particle_obj.px; 
+    this->px_corr = particle_obj.px_corr; 
     this->py = particle_obj.py; 
+    this->py_corr = particle_obj.py_corr; 
     this->pz = particle_obj.pz; 
+    this->pz_corr = particle_obj.pz_corr; 
     this->vtx_x = particle_obj.vtx_x;
     this->vtx_y = particle_obj.vtx_y;
     this->vtx_z = particle_obj.vtx_z;
@@ -126,6 +135,12 @@ void HpsParticle::setMomentum(const double* momentum) {
     pz = momentum[2];
 }
 
+void HpsParticle::setCorrMomentum(const double* momentum) {
+    px_corr = momentum[0];
+    py_corr = momentum[1];
+    pz_corr = momentum[2];
+}
+
 void HpsParticle::setVertexPosition(const float* vtx_pos) {
     vtx_x = (double) vtx_pos[0];
     vtx_y = (double) vtx_pos[1];
@@ -149,6 +164,11 @@ std::vector<double> HpsParticle::getMomentum() const {
     momentum[0] = px;
     momentum[1] = py;
     momentum[2] = pz;
+    return momentum;
+}
+
+std::vector<double> HpsParticle::getCorrMomentum() const {
+    std::vector<double> momentum {px, py, pz};
     return momentum;
 }
 


### PR DESCRIPTION
These changes are needed for analysis code to work correctly at JLab.  The DST maker still needs to be updated so the corrected momentum can be written an HpsParticle.