### PR TITLE
Add the getNumberOfMCParticles() method.

### DIFF
--- a/include/hps_event/HpsEvent.h
+++ b/include/hps_event/HpsEvent.h
@@ -247,8 +247,14 @@ class HpsEvent : public TObject {
         /** */
         int getNumberOfEcalClusters()   const  { return n_ecal_clusters; };
        
+  
         /**
-         * Get the number of particles ({@link HpsParticle} objects) of the 
+         * Get the number of MC particles ({@link HpsMCParticle}) objects in the event.
+         */
+        int getNumberOfMCParticles() const { return n_mc_particles; };
+  
+        /**
+         * Get the number of particles ({@link HpsParticle} objects) of the
          * given {@link HpsParticle::ParticleType} in the event.
          *
          * @param type The type of particle that is being requested e.g. 


### PR DESCRIPTION
Tested via ROOT command line on wabv1-egsv3-triv2-g4v1_1to1_HPS-EngRun2015-Nominal-v4-4-fieldmap_3.8-fix_pairs1_1000.root. Behaves as expected. 