### PR TITLE
Surrounded the line that checks if the   track collection is

### DIFF
--- a/src/dst/SvtDataWriter.cxx
+++ b/src/dst/SvtDataWriter.cxx
@@ -107,7 +107,11 @@ void SvtDataWriter::writeData(EVENT::LCEvent* event, HpsEvent* hps_event) {
        
         // Don't write partial tracks to the DST.  Partial tracks are tracks
         // whose hits are a subset of another track in the event.
-        if (tracks == (EVENT::LCCollection*) event->getCollection(PARTIAL_TRACKS_COL_NAME)) continue;
+    	try {
+    		if (tracks == (EVENT::LCCollection*) event->getCollection(PARTIAL_TRACKS_COL_NAME)) continue;
+    	} catch (EVENT::DataNotAvailableException e) {
+    		//if there is no partial tracks collection, forget about it.
+    	}
 
         // Loop over all the LCIO Tracks and add them to the HPS event.
         for (int track_n = 0; track_n < tracks->getNumberOfElements(); ++track_n) {


### PR DESCRIPTION
PartialTracks in a try-cache block.  This should fix the problem where
reconstructed data without the PartialTracks collection gives an error.  