### PR TITLE
Update schema numbers for MCParticle and HpsMCParticle

### DIFF
--- a/include/hps_event/HpsMCParticle.h
+++ b/include/hps_event/HpsMCParticle.h
@@ -42,7 +42,7 @@ class HpsMCParticle : public TObject {
 		std::vector<double> getMomentum() const;
 		std::vector<double> getEndpoint() const;
 
-		ClassDef(HpsMCParticle, 1)
+		ClassDef(HpsMCParticle, 2)
 
 	private:
 

--- a/include/hps_event/MCParticle.h
+++ b/include/hps_event/MCParticle.h
@@ -292,7 +292,7 @@ class MCParticle : public TObject {
         /**
          * ROOT class definition.
          */
-        ClassDef(MCParticle, 1);
+        ClassDef(MCParticle, 2);
 
 }; // MCParticle
 


### PR DESCRIPTION
Seems nearly trivial 😸 
Updated the ClassDef for MCParticle and HPSMCParticle. Confirmed that now old data DSTs and old MC DSTs are accessible. At least they don't crash the code. Note that items added to the classes since the file was written will be empty. A new DST has to be written in order to fill them.